### PR TITLE
Some minor generalisations with added region support 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,9 @@
 # jmeter-ec2 - Install Script (Runs on remote ec2 server)
 #
 
+# Source the jmeter-ec2.properties file, establishing these constants.
+. /tmp/jmeter-ec2.properties
+
 REMOTE_HOME=$1
 INSTALL_JAVA=$2
 JMETER_VERSION=$3
@@ -25,13 +28,13 @@ if [ $INSTALL_JAVA -eq 1 ] ; then
     # install java
     bits=`getconf LONG_BIT`
     if [ $bits -eq 32 ] ; then
-        wget -q -O $REMOTE_HOME/jre-6u30-linux-i586-rpm.bin https://s3.amazonaws.com/jmeter-ec2/jre-6u30-linux-i586-rpm.bin
-        chmod 755 $REMOTE_HOME/jre-6u30-linux-i586-rpm.bin
-        $REMOTE_HOME/jre-6u30-linux-i586-rpm.bin
+        wget -q -O $REMOTE_HOME/$JAVA_VERSION_32 https://s3.amazonaws.com/jmeter-ec2/$JAVA_VERSION_32
+        chmod 755 $REMOTE_HOME/$JAVA_VERSION_32
+        $REMOTE_HOME/$JAVA_VERSION_32
     else # 64 bit
-        wget -q -O $REMOTE_HOME/jre-6u30-linux-x64-rpm.bin https://s3.amazonaws.com/jmeter-ec2/jre-6u30-linux-i586-rpm.bin
-        chmod 755 $REMOTE_HOME/jre-6u30-linux-x64-rpm.bin
-        $REMOTE_HOME/jre-6u30-linux-x64-rpm.bin
+        wget -q -O $REMOTE_HOME/$JAVA_VERSION_64 https://s3.amazonaws.com/jmeter-ec2/$JAVA_VERSION_64
+        chmod 755 $REMOTE_HOME/$JAVA_VERSION_64
+        $REMOTE_HOME/$JAVA_VERSION_64
     fi
 fi
 

--- a/jmeter-ec2.properties
+++ b/jmeter-ec2.properties
@@ -15,16 +15,20 @@
 #
 LOCAL_HOME="/home/ubuntu"       # The root for this script - all files should be put here as per the README
 REMOTE_HOME="/tmp"                          # This can be left as /tmp - it is a temporary working location
-AMI_ID="ami-a5e7dad1"                       # A suitable AMI - 2 suggested AMIs are listed above. (Tested OK with SUSE Linux 32 & 64 bit.)
+AMI_ID="ami-a5e7dad1"                       # A suitable AMI - 2 suggested AMIs are listed above. (Tested OK with SUSE Linux 32 & 64 bit.). Dont forget to find the right ID for your region.
 INSTANCE_TYPE="t1.micro"                    # Should match the AMI - I do not recommend usng micros for live tests but it's useful for dev work
 INSTANCE_SECURITYGROUP="jmeter"             # The name of *your* security group in *your* Amazon account - clearly this needs to give your local machine ssh access
-PEM_FILE="olloyd-eu"                        # The name of the pem file you downloaded from your Amazon account
+AMAZON_KEYPAIR_NAME="olloyd-eu"	            # The name of the Amazon Keypair that you want to use. This kea/usery should exist in IAM.
+PEM_FILE="olloyd-eu.pem"                    # The full name of the pem file you downloaded from your Amazon account. Usualy .pem from AWS but you could generate your own and name it what you want.
 PEM_PATH="/Users/oliver/.ec2"               # The path to your pem file
-INSTANCE_AVAILABILITYZONE="eu-west-1b"      # Should match the AMI
+REGION="eu-west-1"			    # Specify the region you will be working in. Required so that we can find the right ami in the right availability zone.
+INSTANCE_AVAILABILITYZONE="eu-west-1b"      # Should match the AMI and be available in the region above.
 USER="root"                                 # Should match the AMI
 RUNNINGTOTAL_INTERVAL="3"                   # How often the script prints running totals to the screen (n * summariser.interval seconds)
 ELASTIC_IPS=""                              # A list of static IPs that can be assigned to each ec2 host. Ignored if not set.
 JMETER_VERSION="apache-jmeter-2.6"          # The version of JMeter to be used. Must be the full name used in the dir structure. Does not work for versions prior to 2.5.1.
+JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit. 
+JAVA_VERSION_64='jre-6u32-linux-x64.bin'    # Specify the JAVA binary you will be using in the case of 64Bit.
 
 # REMOTE_HOSTS
 #

--- a/jmeter.sh
+++ b/jmeter.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+##   Licensed to the Apache Software Foundation (ASF) under one or more
+##   contributor license agreements.  See the NOTICE file distributed with
+##   this work for additional information regarding copyright ownership.
+##   The ASF licenses this file to You under the Apache License, Version 2.0
+##   (the "License"); you may not use this file except in compliance with
+##   the License.  You may obtain a copy of the License at
+## 
+##       http://www.apache.org/licenses/LICENSE-2.0
+## 
+##   Unless required by applicable law or agreed to in writing, software
+##   distributed under the License is distributed on an "AS IS" BASIS,
+##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##   See the License for the specific language governing permissions and
+##   limitations under the License.
+
+## Basic JMeter startup script for Un*x systems
+## See the "jmeter" script for details of options that can be used for Sun JVMs
+
+##   ==============================================
+##   Environment variables:
+##   JVM_ARGS - optional /tmp/jre1.6.0_32/bin/java args, e.g. -Dprop=val
+##
+##   e.g.
+##   JVM_ARGS="-Xms512m -Xmx512m" jmeter.sh etc.
+##
+##   ==============================================
+
+# Add Mac-specific property - should be ignored elsewhere (Bug 47064)
+/tmp/jre1.6.0_32/bin/java $JVM_ARGS -Dapple.laf.useScreenMenuBar=true -jar `dirname $0`/ApacheJMeter.jar "$@"

--- a/stoptest.sh
+++ b/stoptest.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+##   Licensed to the Apache Software Foundation (ASF) under one or more
+##   contributor license agreements.  See the NOTICE file distributed with
+##   this work for additional information regarding copyright ownership.
+##   The ASF licenses this file to You under the Apache License, Version 2.0
+##   (the "License"); you may not use this file except in compliance with
+##   the License.  You may obtain a copy of the License at
+## 
+##       http://www.apache.org/licenses/LICENSE-2.0
+## 
+##   Unless required by applicable law or agreed to in writing, software
+##   distributed under the License is distributed on an "AS IS" BASIS,
+##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##   See the License for the specific language governing permissions and
+##   limitations under the License.
+
+#   Run the Shutdown client to stop a non-GUI instance abruptly
+
+#   P1 = command port for JMeter instance (defaults to 4445)
+
+DIRNAME=`dirname $0`
+
+/tmp/jre1.6.0_32/bin/java -cp ${DIRNAME}/ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient StopTestNow "$@"


### PR DESCRIPTION
Very nice work on this tool!! You have made something great here. ;) I
would like to submit the following few changes in case others might
find them useful.

install.sh uses jmeter-ec2.properties to define JAVA_VERSION for 32 and
64 bit

Add AMAZON_KEYPAIR_NAME so that PEM_FILE can reference any file as we
may be using a rya key and the name might not match the key pair name
in AWS.
Add region property so that users can actually spark something up in a
different regions and AZ like eh-west-1b.

Add JAVA_VERSIONs for 32 and 64bit used by install.sh

jmeter-ec.sh add region and support to commands remove .pem from
PEM_FILE name as it is not necessary now using PEM_FILE. SCP some more
files up like the stop script that I had to modify to explicitly look
at my java dir. Likely an issue with PATHs but haven't had much luck
fixing it as yet. profile.d config was correct… Add meter.sh and
stoptest.sh as it wasn't using the JAVA_HOME I had configured.
