### PR TITLE
Error Checking and Assigning default value

### DIFF
--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -308,8 +308,8 @@ function runsetup() {
     fi
 	
     # scp install.sh
-    if [ "$setup" == "TRUE" ] ; then
-    	echo "copying install.sh to $instance_count server(s)..."
+    if [ "$setup" = "TRUE" ] ; then
+    	echo -n "copying install.sh to $instance_count server(s)..."
 	    for host in ${hosts[@]} ; do
 	        (scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
 	                                      -i $PEM_PATH/$PEM_FILE \
@@ -507,7 +507,7 @@ function runsetup() {
     echo -n "done...."
     
     # scp data dir
-    if [ "$setup" == "TRUE" ] ; then
+    if [ "$setup" = "TRUE" ] ; then
     	if [ -r $LOCAL_HOME/$project/data ] ; then # don't try to upload this optional dir if it is not present
 	        echo -n "data dir.."
 	        for host in ${hosts[@]} ; do


### PR DESCRIPTION
Hello! This is my first pull request, so please bear with me. It's such a wonderful tool and I've made many changes to it. I am trying to organize the changes I made and hope this will help improve upon it.

The initial changes I am submitting are the following:
1) Give default value of "1" to $count variable, if it doesn't have a value.
2) Added function check_prereqs(), which will do some basic error and sanity checking before running.
3) In the tidy up sections, did tests to check if files existed before rm'ing them. Otherwise, the script will display error messages with could confuse users.
