### PR TITLE
Decouple project home from jmeter-ec2 code

### DIFF
--- a/jmeter-ec2.properties
+++ b/jmeter-ec2.properties
@@ -1,34 +1,35 @@
+#!/bin/bash
+
 # This is a java stye properties file for the jmeter-ec2 shell script
 #
-# It is treated like a normal shell script and must have executable permissions
+# It is treated like a normal shell script
 #
 # See README.txt for more details about each property
 #
 #
 # Suggested AMIs
 #
-# OS            Type   AMI id        User       Available sizes
+# OS          Type   AMI id        User       Available sizes
 # Ubuntu	    64bit  ami-e1e8d395  ubuntu     t1.micro, m1.small, m1.medium, c1.medium, m1.large, m1.xlarge, etc.
 #
 # IMPORTANT - t1.micro is not recommend for anything beyond developement, it works from a shared resource pool that can fluctuate, skewing test results.
 #
-LOCAL_HOME="/Users/oliverlloyd/JMeter"      # The root for this script - all files should be put here as per the README
 REMOTE_HOME="/tmp"                          # This can be left as /tmp - it is a temporary working location
 AMI_ID="ami-e1e8d395"                       # A suitable AMI - 2 suggested AMIs are listed above. (Tested OK with SUSE Linux 32 & 64 bit.). Dont forget to find the right ID for your region.
 INSTANCE_TYPE="t1.micro"                    # Should match the AMI - I do not recommend usng micros for live tests but it's useful for dev work
 INSTANCE_SECURITYGROUP="jmeter"             # The name of *your* security group in *your* Amazon account - clearly this needs to give your local machine ssh access
 AMAZON_KEYPAIR_NAME="olloyd-eu"	            # The name of the Amazon Keypair that you want to use. This kea/usery should exist in IAM.
 PEM_FILE="olloyd-eu.pem"                    # The full name of the pem file you downloaded from your Amazon account. Usualy .pem from AWS but you could generate your own and name it what you want.
-PEM_PATH="/Users/oliverlloyd/.ec2"               # The path to your pem file
+PEM_PATH=$HOME/.ssh                         # The path to your pem file
 USER="ubuntu"                               # Should match the AMI
-EMAIL=""									# Email to be used when tagging instances
-REGION="eu-west-1"			    			# Specify the region you will be working in. Required so that we can find the right ami in the right availability zone.
+EMAIL=""									                  # Email to be used when tagging instances
+REGION="eu-west-1"			    			          # Specify the region you will be working in. Required so that we can find the right ami in the right availability zone.
 INSTANCE_AVAILABILITYZONE="eu-west-1b"      # Should match the AMI and be available in the region above.
 RUNNINGTOTAL_INTERVAL="3"                   # How often the script prints running totals to the screen (n * summariser.interval seconds)
 ELASTIC_IPS=""                              # A list of static IPs that can be assigned to each ec2 host. Ignored if not set.
 REMOTE_PORT="22"                            # The port number sshd is running on,
 JMETER_VERSION="apache-jmeter-2.7"          # The version of JMeter to be used. Must be the full name used in the dir structure. Does not work for versions prior to 2.5.1.
-JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit. 
+JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit.
 JAVA_VERSION_64='jre-6u32-linux-x64.bin'    # Specify the JAVA binary you will be using in the case of 64Bit.
 
 # REMOTE_HOSTS
@@ -52,5 +53,5 @@ DB_NAME=""
 DB_USER=""
 DB_PSWD=""
 DB_PEM_FILE=""
-DB_PEM_PATH="" 
+DB_PEM_PATH=""
 DB_PEM_USER=""

--- a/jmeter-ec2.properties.vagrant
+++ b/jmeter-ec2.properties.vagrant
@@ -1,6 +1,8 @@
+# #!/bin/bash
+
 # This is a java stye properties file for the jmeter-ec2 shell script
 #
-# It is treated like a normal shell script and must have executable permissions
+# It is treated like a normal shell script
 #
 # See README.txt for more details about each property
 #
@@ -11,7 +13,7 @@ PEM_PATH="$HOME/.vagrant.d"               # The path to your pem file
 USER="vagrant"                               # Should match the AMI
 REMOTE_PORT="2222"                            # The port number sshd is running on,
 JMETER_VERSION="apache-jmeter-2.7"          # The version of JMeter to be used. Must be the full name used in the dir structure. Does not work for versions prior to 2.5.1.
-JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit. 
+JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit.
 JAVA_VERSION_64='jre-6u32-linux-x64.bin'    # Specify the JAVA binary you will be using in the case of 64Bit.
 
 # REMOTE_HOSTS
@@ -25,5 +27,5 @@ DB_NAME=""
 DB_USER=""
 DB_PSWD=""
 DB_PEM_FILE=""
-DB_PEM_PATH="" 
+DB_PEM_PATH=""
 DB_PEM_USER=""


### PR DESCRIPTION
This makes it easier to have one instance of jmeter-ec2 on your machine, but store multiple test setups in different places.

Auto detect `$LOCAL_HOME` and `$project` and use `$project_home` in place of `$LOCAL_HOME/$project`.

Remove unneeded executable permission on `*.properties` files (since they are sourced with `.`, they don't need to be executable).

Finally, a bunch of really small whitespace cleanups (my linter automatically does the clean up).
