### PR TITLE
Update jmeter-ec2.properties.vagrant

### DIFF
--- a/jmeter-ec2.properties.vagrant
+++ b/jmeter-ec2.properties.vagrant
@@ -13,6 +13,7 @@ REMOTE_PORT="2222"                            # The port number sshd is running 
 JMETER_VERSION="apache-jmeter-2.7"          # The version of JMeter to be used. Must be the full name used in the dir structure. Does not work for versions prior to 2.5.1.
 JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit. 
 JAVA_VERSION_64='jre-6u32-linux-x64.bin'    # Specify the JAVA binary you will be using in the case of 64Bit.
+RUNNINGTOTAL_INTERVAL="3"                   # How often the script prints running totals to the screen (n * summariser.interval seconds)
 
 # REMOTE_HOSTS
 REMOTE_HOSTS="127.0.0.1"


### PR DESCRIPTION
Missing attribute RUNNINGTOTAL_INTERVAL.
