### PR TITLE
Adding support for EC2-VPC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ IMPORTANT - There is a limit imposed by Amazon on how many instances can be run 
 * File paths cannot be dynamic, any variables in the filepath will be ignored.
 
 
-## Pre-requisits
+## Prerequisites
 * **An Amazon ec2 account is required** unless valid hosts are specified using REMOTE_HOSTS property.
 * Amazon API tools must be installed as per Amazon's instructions (only in ec2 mode).
 * Testplans should have a Generate Summary Results Listener present and enabled (no other listeners are required).
@@ -68,7 +68,7 @@ IMPORTANT - There is a limit imposed by Amazon on how many instances can be run 
 	(only in ec2 mode) This depends on the type of AMI - it must be available for the AMI used.
 
 	`INSTANCE_SECURITYGROUP="jmeter"`
-	(only in ec2 mode) The name of your security group created under your Amazon account. It must allow Port 22 to the local machine running this script.
+	(only in ec2 mode) The name or ID of your security group created under your Amazon account. It must allow Port 22 to the local machine running this script. In order to use EC2-VPC, you must specify the ID of the security group.
 
 	`PEM_FILE="olloyd-eu"`
 	(only in ec2 mode) Your Amazon key file - obviously must be installed locally.
@@ -81,6 +81,9 @@ IMPORTANT - There is a limit imposed by Amazon on how many instances can be run 
 
 	`USER="ubuntu"`
 	(only in ec2 mode) Different AMIs start with different basic users. This value could be 'ec2-user', 'root', 'ubuntu' etc.
+
+    `SUBNET_ID=""`
+    (only in ec2-vpc mode) The id of the subnet that the instance will belong to.
 
 	`RUNNINGTOTAL_INTERVAL="3"`
 	How often running totals are printed to the screen. Based on a count of the summariser.interval property. (If the Generate Summary Results listener is set to wait 10 seconds then every 30 (3 * 10) seconds an extra row showing an agraggated summary will be printed.) The summariser.interval property in the standard jmeter.properties file defaults to 180 seconds - in the file included with this project it is set to 15 seconds, like this we default to summary updates every 45 seconds.

--- a/jmeter-ec2.properties
+++ b/jmeter-ec2.properties
@@ -17,13 +17,13 @@
 REMOTE_HOME="/tmp"                          # This can be left as /tmp - it is a temporary working location
 AMI_ID="ami-e1e8d395"                       # A suitable AMI - 2 suggested AMIs are listed above. (Tested OK with SUSE Linux 32 & 64 bit.). Dont forget to find the right ID for your region.
 INSTANCE_TYPE="t1.micro"                    # Should match the AMI - I do not recommend usng micros for live tests but it's useful for dev work
-INSTANCE_SECURITYGROUP="jmeter"             # The name of *your* security group in *your* Amazon account - clearly this needs to give your local machine ssh access
+INSTANCE_SECURITYGROUP="jmeter"             # The name OR id of *your* security group in *your* Amazon account - clearly this needs to give your local machine ssh access.
 AMAZON_KEYPAIR_NAME="olloyd-eu"	            # The name of the Amazon Keypair that you want to use. This kea/usery should exist in IAM.
 PEM_FILE="olloyd-eu.pem"                    # The full name of the pem file you downloaded from your Amazon account. Usualy .pem from AWS but you could generate your own and name it what you want.
 PEM_PATH=$HOME/.ssh                         # The path to your pem file
 USER="ubuntu"                               # Should match the AMI
-EMAIL=""									                  # Email to be used when tagging instances
-REGION="eu-west-1"			    			          # Specify the region you will be working in. Required so that we can find the right ami in the right availability zone.
+EMAIL=""									# Email to be used when tagging instances
+REGION="eu-west-1"			    			# Specify the region you will be working in. Required so that we can find the right ami in the right availability zone.
 INSTANCE_AVAILABILITYZONE="eu-west-1b"      # Should match the AMI and be available in the region above.
 RUNNINGTOTAL_INTERVAL="3"                   # How often the script prints running totals to the screen (n * summariser.interval seconds)
 ELASTIC_IPS=""                              # A list of static IPs that can be assigned to each ec2 host. Ignored if not set.
@@ -31,6 +31,19 @@ REMOTE_PORT="22"                            # The port number sshd is running on
 JMETER_VERSION="apache-jmeter-2.7"          # The version of JMeter to be used. Must be the full name used in the dir structure. Does not work for versions prior to 2.5.1.
 JAVA_VERSION_32='jre-6u32-linux-i586.bin'   # Specify the JAVA binary you will be using in the case of 32Bit.
 JAVA_VERSION_64='jre-6u32-linux-x64.bin'    # Specify the JAVA binary you will be using in the case of 64Bit.
+
+
+#
+# EC2-VPC Usage
+# 
+# jmeter-ec2 can configure EC2-VPC instances. You must:
+#   - set SUBNET_ID to the id of the subnet that the instance will belong to
+#   - set INSTANCE_SECURITYGROUP to be the id of the security group, rather than the name of the security group
+#   - make sure that the AMI is compatible with EC2-VPC
+#   - enable DNS Resolution in the VPC
+#   - enable DNS hostnames in the VPC
+# 
+SUBNET_ID=""                 # The subnet that the instance will belong to.
 
 # REMOTE_HOSTS
 #

--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -151,6 +151,10 @@ function runsetup() {
         echo
         echo
 
+        vpcsettings=""
+
+        if [ -n "$SUBNET_ID" ] ; then vpcsettings="-s $SUBNET_ID --associate-public-ip-address \"true\""; fi
+
         # create the instance(s) and capture the instance id(s)
         echo -n "requesting $instance_count instance(s)..."
         attempted_instanceids=(`ec2-run-instances \
@@ -158,6 +162,7 @@ function runsetup() {
                     -t "$INSTANCE_TYPE" \
                     -g "$INSTANCE_SECURITYGROUP" \
                     -n 1-$instance_count \
+                    $vpcsettings \
 		            --region $REGION \
                     --availability-zone \
                     $INSTANCE_AVAILABILITYZONE $AMI_ID \


### PR DESCRIPTION
We need to use jmeter-ec2, but all of our instances live in VPCs. I've modified the scripts and config files to support adding instances to EC2-VPC.
