### PR TITLE
Correct some typos for OSX

### DIFF
--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -387,7 +387,7 @@ function runsetup() {
 	        if [ ! "$(ssh -q \
 	            -o StrictHostKeyChecking=no \
 	            -o "BatchMode=yes" \
-	            -o "ConnectTimeout 15" \
+	            -o "ConnectTimeout=15" \
 	            -i "$PEM_PATH/$PEM_FILE" \
 	            -p $REMOTE_PORT \
 	            $USER@$host echo up 2>&1)" == "up" ] ; then

--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -384,7 +384,7 @@ function runsetup() {
 
 	    # Check if remote hosts are up
 	    for host in ${hosts[@]} ; do
-	        if [ ! "$(ssh -q -q \
+	        if [ ! "$(ssh -q \
 	            -o StrictHostKeyChecking=no \
 	            -o "BatchMode=yes" \
 	            -o "ConnectTimeout 15" \

--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -933,7 +933,7 @@ function runcleanup() {
 	start_time=$(head -1 $project_home/$project-$DATETIME-complete.jtl | cut -d',' -f1)
 	end_time=$(tail -1 $project_home/$project-$DATETIME-complete.jtl | cut -d',' -f1)
 	duration=$(echo "$end_time-$start_time" | bc)
-	if [ ! $duration > 0 ] ; then
+	if [ ! $duration -gt 0 ] ; then
 		duration=0;
 	fi
 

--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -390,7 +390,7 @@ function runsetup() {
 	            -o "ConnectTimeout=15" \
 	            -i "$PEM_PATH/$PEM_FILE" \
 	            -p $REMOTE_PORT \
-	            $USER@$host echo up 2>&1)" == "up" ] ; then
+	            $USER@$host echo up)" == "up" ] ; then
 	            echo "Host $host is not responding, script exiting..."
 	            echo
 	            exit

--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -930,8 +930,8 @@ function runcleanup() {
 	sed '/^0,0,Error:/d' $project_home/$project-$DATETIME-noblanks.jtl >> $project_home/$project-$DATETIME-complete.jtl
 
 	# Calclulate test duration
-	start_time=$(head -1 $project_home/$project-$DATETIME-complete.jtl | cut -d',' -f2)
-	end_time=$(tail -1 $project_home/$project-$DATETIME-complete.jtl | cut -d',' -f2)
+	start_time=$(head -1 $project_home/$project-$DATETIME-complete.jtl | cut -d',' -f1)
+	end_time=$(tail -1 $project_home/$project-$DATETIME-complete.jtl | cut -d',' -f1)
 	duration=$(echo "$end_time-$start_time" | bc)
 	if [ ! $duration > 0 ] ; then
 		duration=0;


### PR DESCRIPTION
- [Line 393](https://github.com/oliverlloyd/jmeter-ec2/compare/master...mrrusof:typos#diff-05d24f8233e590a986961f0193259df0L393): by redirecting stderr to stdout, spurious warnings during login (e.g. `bash: warning: setlocale: LC_ALL: cannot change locale (en_US.ISO8859-1)`) stop the script with message `Host $host is not responding, script exiting...`.
- [Line 933](https://github.com/oliverlloyd/jmeter-ec2/compare/master...mrrusof:typos#diff-05d24f8233e590a986961f0193259df0L933): AFAIS, JMeter 2.7 have timestamp in first column.
- [Line 936](https://github.com/oliverlloyd/jmeter-ec2/compare/master...mrrusof:typos#diff-05d24f8233e590a986961f0193259df0L936): Lexicographical comparison is not escaped and I prefer numerical comparison.