### PR TITLE
Including system.properties in deployable files

### DIFF
--- a/jmeter-ec2.sh
+++ b/jmeter-ec2.sh
@@ -653,6 +653,32 @@ function runsetup() {
       echo -n "done...."
     fi
 
+    # scp system.properties
+    if [ -r $LOCAL_HOME/system.properties ] ; then # don't try to upload this optional file if it is not present
+      echo -n "system.properties.."
+      for host in ${hosts[@]} ; do
+          (scp -q -C -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+                                        -i "$PEM_PATH/$PEM_FILE" -P $REMOTE_PORT \
+                                        $LOCAL_HOME/system.properties \
+                                        $USER@$host:$REMOTE_HOME/$JMETER_VERSION/bin/) &
+      done
+      wait
+      echo -n "done...."
+    fi
+
+    # scp keystore
+    if [ -r $LOCAL_HOME/keystore.jks ] ; then # don't try to upload this optional file if it is not present
+      echo -n "keystore.jks.."
+      for host in ${hosts[@]} ; do
+          (scp -q -C -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+                                        -i "$PEM_PATH/$PEM_FILE" -P $REMOTE_PORT \
+                                        $LOCAL_HOME/keystore.jks \
+                                        $USER@$host:$REMOTE_HOME) &
+      done
+      wait
+      echo -n "done...."
+    fi
+
     # scp jmeter execution file
     if [ -r $LOCAL_HOME/jmeter ] ; then # don't try to upload this optional file if it is not present
       echo -n "jmeter execution file..."

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,113 @@
+# Sample system.properties file
+#
+##   Licensed to the Apache Software Foundation (ASF) under one or more
+##   contributor license agreements.  See the NOTICE file distributed with
+##   this work for additional information regarding copyright ownership.
+##   The ASF licenses this file to You under the Apache License, Version 2.0
+##   (the "License"); you may not use this file except in compliance with
+##   the License.  You may obtain a copy of the License at
+## 
+##       http://www.apache.org/licenses/LICENSE-2.0
+## 
+##   Unless required by applicable law or agreed to in writing, software
+##   distributed under the License is distributed on an "AS IS" BASIS,
+##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##   See the License for the specific language governing permissions and
+##   limitations under the License.
+
+#    Commons Logging properties
+#    Used by HttpComponents 4.x, see: 
+#    http://hc.apache.org/httpcomponents-client-4.3.x/logging.html
+#
+# By default, Commons Logging is configured by JMeter to use the same logging system
+# as the main JMeter code; to configure it please see jmeter.properties.
+#
+# Uncomment to enable debugging of Commons Logging setup; may be useful if
+# implementation cannot be instantiated:
+#org.apache.commons.logging.diagnostics.dest=STDERR
+#
+# Uncomment to enable Commons Logging to use standard output
+#org.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
+#org.apache.commons.logging.simplelog.showdatetime=true
+#
+# Uncomment the following two lines to generate basic debug logging for HC4.x
+#org.apache.commons.logging.simplelog.log.org.apache.http=DEBUG
+#org.apache.commons.logging.simplelog.log.org.apache.http.wire=ERROR
+
+# Java networking-related properties
+#
+# For details of Oracle Java network properties, see for example:
+# http://download.oracle.com/javase/1.5.0/docs/guide/net/properties.html
+#
+#java.net.preferIPv4Stack=false
+#java.net.preferIPv6Addresses=false
+#networkaddress.cache.ttl=-1
+#networkaddress.cache.negative.ttl=10
+
+#
+#
+# SSL properties (moved from jmeter.properties)
+#
+# See http://download.oracle.com/javase/1.5.0/docs/guide/security/jsse/JSSERefGuide.html#Customization
+# for information on the javax.ssl system properties
+
+# Truststore properties (trusted certificates)
+#javax.net.ssl.trustStore
+#javax.net.ssl.trustStorePassword
+#javax.net.ssl.trustStoreProvider
+#javax.net.ssl.trustStoreType [default = KeyStore.getDefaultType()]
+
+# Keystore properties (client certificates)
+# Location
+#javax.net.ssl.keyStore
+#
+#The password to your keystore
+#javax.net.ssl.keyStorePassword
+#
+#javax.net.ssl.keyStoreProvider
+#javax.net.ssl.keyStoreType [default = KeyStore.getDefaultType()]
+
+# SSL debugging:
+# See http://download.oracle.com/javase/1.5.0/docs/guide/security/jsse/JSSERefGuide.html#Debug
+#
+# javax.net.debug=help - generates the list below:
+#all            turn on all debugging
+#ssl            turn on ssl debugging
+#
+#The following can be used with ssl:
+#        record       enable per-record tracing
+#        handshake    print each handshake message
+#        keygen       print key generation data
+#        session      print session activity
+#        defaultctx   print default SSL initialization
+#        sslctx       print SSLContext tracing
+#        sessioncache print session cache tracing
+#        keymanager   print key manager tracing
+#        trustmanager print trust manager tracing
+#
+#        handshake debugging can be widened with:
+#        data         hex dump of each handshake message
+#        verbose      verbose handshake message printing
+#
+#        record debugging can be widened with:
+#        plaintext    hex dump of record plaintext
+#
+# Examples:
+#javax.net.debug=ssl
+#javax.net.debug=sslctx,session,sessioncache
+#
+#
+# We enable the following property to allow headers such as "Host" to be passed through.
+# See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6996110
+sun.net.http.allowRestrictedHeaders=true
+
+#Uncomment for Kerberos authentication and edit the 2 config files to match your domains
+#With the following configuration krb5.conf and jaas.conf must be located in bin folder
+#You can modify these file paths to use absolute location
+#java.security.krb5.conf=krb5.conf
+#java.security.auth.login.config=jaas.conf
+
+# Location of keytool application
+# This property can be defined if JMeter cannot find the application automatically
+# It should not be necessary in most cases.
+#keytool.directory=<Java Home Directory>/bin


### PR DESCRIPTION
Added the capability to deploy system.properties and a keystore file. These are both treated as optional so will be ignored if not found.

System.properties specifies the configuration for ssl behaviour as well as key/trust stores which has beenmoved out of the jmeter.properties.